### PR TITLE
MoneyItem 리렌더링 이슈 해결

### DIFF
--- a/src/components/Wallet/MoneyItem/MoneyItem.jsx
+++ b/src/components/Wallet/MoneyItem/MoneyItem.jsx
@@ -1,16 +1,16 @@
-import { useContext } from "react";
+import { memo, useContext } from 'react';
 
-import Button from "components/common/form/Button/Button";
-import { MoneyContext } from "pages/Layout/Layout";
+import Button from 'components/common/form/Button/Button';
+import { setMoneyContext } from 'pages/Layout/Layout';
 
-import { MoneyLi, moneyButtonStyle } from "./MoneyItem.styled";
+import { MoneyLi, moneyButtonStyle } from './MoneyItem.styled';
 
 const Count = ({ data }) => {
   return <p className="count">{data}</p>;
 };
 
-const MoneyItem = ({ onClick }) => {
-  const { money, count } = useContext(MoneyContext);
+const MoneyItem = ({ money, count }) => {
+  const handleClickButton = useContext(setMoneyContext);
 
   return (
     <MoneyLi>
@@ -19,11 +19,11 @@ const MoneyItem = ({ onClick }) => {
         data={{ name: money }}
         styles={moneyButtonStyle}
         isDisabled={!count}
-        onClick={onClick}
+        onClick={() => handleClickButton(money)}
       />
       <Count data={count} />
     </MoneyLi>
   );
 };
 
-export default MoneyItem;
+export default memo(MoneyItem);

--- a/src/pages/Layout/Layout.jsx
+++ b/src/pages/Layout/Layout.jsx
@@ -1,10 +1,10 @@
-import React, { useCallback, useMemo, useState } from "react";
+import React, { useCallback, useMemo, useState } from 'react';
 
-import Navbar from "components/Navbar/NavBar";
-import cash from "mockData/money";
-import { Outlet } from "react-router-dom";
+import Navbar from 'components/Navbar/NavBar';
+import cash from 'mockData/money';
+import { Outlet } from 'react-router-dom';
 
-import { Wrap, Main } from "./Layout.styled";
+import { Wrap, Main } from './Layout.styled';
 
 // TODO: context 분리하기
 export const MoneyContext = React.createContext({});
@@ -16,18 +16,15 @@ const Layout = ({ menusData }) => {
 
   // NOTE: useMemo, useCallback사용에도 re-rendering이 되는 곳
   // (lint설정으로 인해 사용해야하기때문에 일단 놔두기😭)
-  const decreaseCashCount = useCallback(
-    (indexNo) =>
-      setCashData(
-        cashData.map((current, i) => {
-          if (i === indexNo) {
-            return { money: current.money, count: current.count - 1 };
-          }
-          return current;
-        })
-      ),
-    [cashData]
-  );
+  const decreaseCashCount = useCallback((money) => {
+    setCashData((prevCashData) =>
+      prevCashData.map((current) => {
+        if (current.money === money) {
+          return { ...current, count: current.count - 1 };
+        }
+        return current;
+      }));
+  }, []);
 
   const money = useMemo(
     () => ({

--- a/src/pages/Wallet/Wallet.jsx
+++ b/src/pages/Wallet/Wallet.jsx
@@ -1,23 +1,16 @@
-import { useContext } from "react";
+import { useContext } from 'react';
 
-import MoneyItem from "components/Wallet/MoneyItem/MoneyItem";
-import TotalMoneyArea from "components/Wallet/TotalMoneyArea/TotalMoneyArea";
-import { MoneyContext, setMoneyContext } from "pages/Layout/Layout";
+import MoneyItem from 'components/Wallet/MoneyItem/MoneyItem';
+import TotalMoneyArea from 'components/Wallet/TotalMoneyArea/TotalMoneyArea';
+import { MoneyContext } from 'pages/Layout/Layout';
 
-import Wrapper from "./Wallet.styled";
+import Wrapper from './Wallet.styled';
 
 const Wallet = () => {
   const { cashData } = useContext(MoneyContext);
-  const handleClickButton = useContext(setMoneyContext);
 
-  const walletItems = cashData.map(({ money }, idx) => {
-    return (
-      // NOTE: 여기서 context의 value를 해당 MoneyItem에 해당하는 것으로 지정하여
-      // 리렌더링을 막아보려 했으나 onClick이벤트에 의해서 전체가 리렌더링 되게 됨🤔
-      <MoneyContext.Provider value={cashData[idx]} key={money}>
-        <MoneyItem onClick={() => handleClickButton(idx)} />
-      </MoneyContext.Provider>
-    );
+  const walletItems = cashData.map(({ money, count }) => {
+    return <MoneyItem key={money} money={money} count={count} />;
   });
 
   return (


### PR DESCRIPTION
file changes에 들어가셔서 어떤 게 바뀌었는지 함께 보세용 ㅎㅎㅎ

3개의 파일에서 변경점이 있어요.

## Layout.jsx

- `setCashData`에서 바로 map해주는 것이 아닌, 함수 형태의 인자로 prevCashData를 변경시킴
- useCallback 의존성 배열에 cashData 삭제
- idx로 비교하던 것을 money 데이터로 비교하도록 변경

## Wallet.jsx

- map으로 MoneyItem을 렌더링할 때 필요한 데이터 money, count를 props로 넘겨주도록 수정
- props로 onClick 넘겨주던 것 삭제
  - 이유: 이 onClick이 리렌더링의 주범이었던 것 같음
  - useCallback으로 감싸보기도 했으나 왜인지 잘 해결이 안됐었어요.. ㅠ

## MoneyItem.jsx

- `MoneyItem` 컴포넌트 전체를 memo로 감싸도록 수정
  - props로 받는 money, count가 변하지 않으면 리렌더링되지 않는 효과
- onClick에 넣어줄 함수를 이곳에서 useContext 사용하여 가져오도록 수정


요렇게 변경하면 MoneyItem이 잘 메모이제이션 돼서 리렌더링이 발생하지 않네요!

제가 보내드리는 PR은 머지는 안 하시는 게 좋을 것 같고 참고용으로만 봐주세요!
